### PR TITLE
Feature: adds ability to generate store with initial app state

### DIFF
--- a/packages/store/src/generateStore.js
+++ b/packages/store/src/generateStore.js
@@ -21,6 +21,7 @@ const composeSagas = sagas =>
  * @param {object[]} config.appSagas=[] - application sagas to be managed by drizzle's saga middleware
  * @param {object[]} config.appMiddlewares=[] - application middlewares to be managed by drizzle's saga middleware
  * @param {boolean} config.disableReduxDevTools=false - disable redux devtools hook
+ * @param {object} config.initialAppState={} - application initial state to include in drizzle's redux store
  * @returns {object} Redux store
  *
  */
@@ -30,6 +31,7 @@ export function generateStore ({
   appSagas = [],
   appMiddlewares = [],
   disableReduxDevTools = false,
+  initialAppState = {},
   ...options
 }) {
   // Note: Preserve backwards compatibility for passing options to
@@ -37,7 +39,7 @@ export function generateStore ({
   // of `generateStore(options)`.
   //
   // The updated signature looks for `drizzleOptions`, `appReducers`,
-  // `appSagas`, `initialAppStore` and `disableReduxDevTools` while
+  // `appSagas`, `appMiddlewares`, `disableReduxDevTools` and `initialAppState` while
   // {...options} captures the previous release's signature.
   //
   // Resolve drizzleOptions. If called by dapps written to previous API, then
@@ -50,17 +52,18 @@ export function generateStore ({
     ? global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
     : compose
 
-  let initialContractsState = {
+  const initialContractsState = {
     contracts: generateContractsInitialState(drizzleOptions)
   }
 
   const sagaMiddleware = createSagaMiddleware()
   const allMiddlewares = [...appMiddlewares, sagaMiddleware, drizzleMW]
   const allReducers = { ...drizzleReducers, ...appReducers }
+  const allState = { ...initialAppState, ...initialContractsState }
 
   const store = createStore(
     combineReducers(allReducers),
-    initialContractsState,
+    allState,
     composeEnhancers(applyMiddleware(...allMiddlewares))
   )
 

--- a/packages/store/test/generateStore.test.js
+++ b/packages/store/test/generateStore.test.js
@@ -63,5 +63,21 @@ describe('generateStore', () => {
       expect(state).toHaveProperty('myState')
       expect(state.myState).toBe(initialState)
     })
+
+    test('when invoked with initialAppState', () => {
+      const initialState = 'This is the initial app State'
+      const myState = jest.fn((state = '') => state)
+      const appReducers = { myState }
+      const initialAppState = { myState: initialState }
+      const store = generateStore({
+        drizzleOptions,
+        appReducers,
+        initialAppState
+      })
+      const state = store.getState()
+      hasBasicShape(state)
+      expect(state).toHaveProperty('myState')
+      expect(state.myState).toBe(initialState)
+    })
   })
 })

--- a/packages/store/types/generateStore.d.ts
+++ b/packages/store/types/generateStore.d.ts
@@ -8,6 +8,7 @@ export interface IStoreConfig {
   appSagas?: any[];
   appMiddlewares?: any[];
   disableReduxDevTools?: boolean;
+  initialAppState?: any;
 }
 
 export function generateStore(config: IStoreConfig): Store;


### PR DESCRIPTION
This PR addresses [Issue 98](https://github.com/trufflesuite/drizzle/issues/98).

* Updates IStoreConfig definition to include initialAppState
* Adds initialAppState param to generateStore, allowing to initialize the store with a custom app state (plus Drizzle's initialContractsState)
* Adds new unit test to generateStore related to appInitialState